### PR TITLE
fix: account for mapped types without modifiers in isPropertyReadonlyInType

### DIFF
--- a/src/types/utilities.test.ts
+++ b/src/types/utilities.test.ts
@@ -1,0 +1,26 @@
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { createSourceFileAndTypeChecker } from "../test/utils";
+import { isPropertyReadonlyInType } from "./utilities";
+
+describe("isPropertyReadonlyInType", () => {
+	it("does not crash when the type is a mapped type parameter extending any", () => {
+		const { sourceFile, typeChecker } = createSourceFileAndTypeChecker(`
+            type MyType<T> = {
+                [K in keyof T]: 'cat' | 'dog' | T[K];
+            };
+            type Test<A extends any[]> = MyType<A>;
+        `);
+		const node = sourceFile.statements.at(-1) as ts.TypeAliasDeclaration;
+		const type = typeChecker.getTypeAtLocation(node);
+
+		expect(
+			isPropertyReadonlyInType(
+				type,
+				ts.escapeLeadingUnderscores("length"),
+				typeChecker
+			)
+		).toBe(false);
+	});
+});

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -92,8 +92,11 @@ function isReadonlyPropertyFromMappedType(
 		!/^__@[^@]+$/.test(name as string)
 	)
 		return declaration.readonlyToken.kind !== ts.SyntaxKind.MinusToken;
-	return isPropertyReadonlyInType(
-		(type as unknown as { modifiersType: ts.Type }).modifiersType,
+
+	const { modifiersType } = type as { modifiersType?: ts.Type };
+
+	return /* modifiersType && */ isPropertyReadonlyInType(
+		modifiersType!,
 		name,
 		typeChecker
 	);

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -95,10 +95,8 @@ function isReadonlyPropertyFromMappedType(
 
 	const { modifiersType } = type as { modifiersType?: ts.Type };
 
-	return /* modifiersType && */ isPropertyReadonlyInType(
-		modifiersType!,
-		name,
-		typeChecker
+	return (
+		modifiersType && isPropertyReadonlyInType(modifiersType, name, typeChecker)
 	);
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #17
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-tools/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-tools/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Checks if `type.modifiersType` exists before asking `isPropertyReadonlyInType(modifiersType, ...)`.

This is a recreation of https://github.com/ajafff/tsutils/pull/136. Which means 😄:

Co-authored-by: @kirjs