### PR TITLE
fix: add missing explicit .js extensions to imports

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -3,7 +3,7 @@
 
 import * as ts from "typescript";
 
-import { forEachToken } from "./tokens";
+import { forEachToken } from "./tokens.js";
 
 /** Exclude trailing positions that would lead to scanning for trivia inside JsxText */
 function canHaveTrailingTrivia(token: ts.Node): boolean {

--- a/src/nodes/utilities.ts
+++ b/src/nodes/utilities.ts
@@ -7,7 +7,7 @@ import {
 	isConstAssertionExpression,
 	isEntityNameExpression,
 	isNumericOrStringLikeLiteral,
-} from "./typeGuards";
+} from "./typeGuards.js";
 
 /** Determines whether a call to `Object.defineProperty` is statically analyzable. */
 export function isBindableObjectDefinePropertyCall(

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -7,7 +7,7 @@ import {
 	isIntersectionType,
 	isUnionType,
 	isUniqueESSymbolType,
-} from "./typeGuards";
+} from "./typeGuards.js";
 
 export function getCallSignaturesOfType(
 	type: ts.Type

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -9,20 +9,20 @@ import {
 	isObjectFlagSet,
 	isSymbolFlagSet,
 	isTypeFlagSet,
-} from "../flags";
+} from "../flags.js";
 import {
 	isBindableObjectDefinePropertyCall,
 	isInConstContext,
-} from "../nodes/utilities";
-import { isNumericPropertyName } from "../syntax";
-import { getPropertyOfType } from "./getters";
+} from "../nodes/utilities.js";
+import { isNumericPropertyName } from "../syntax.js";
+import { getPropertyOfType } from "./getters.js";
 import {
 	isIntersectionType,
 	isLiteralType,
 	isObjectType,
 	isTupleTypeReference,
 	isUnionType,
-} from "./typeGuards";
+} from "./typeGuards.js";
 
 /** Determines whether the given type is a boolean literal type and matches the given boolean literal. */
 export function isBooleanLiteralType(type: ts.Type, literal: boolean): boolean {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #35
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds missing `.js` extensions where needed.