### PR TITLE
refactor: use `JSDoc` over `JSDocComment`

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -22,9 +22,7 @@ export function forEachToken(
 	while (true) {
 		if (ts.isTokenKind(node.kind)) {
 			callback(node);
-			// TODO: Investigate?
-			// eslint-disable-next-line deprecation/deprecation
-		} else if (node.kind !== ts.SyntaxKind.JSDocComment) {
+		} else if (node.kind !== ts.SyntaxKind.JSDoc) {
 			const children = node.getChildren(sourceFile);
 			if (children.length === 1) {
 				node = children[0];


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`JSDoc` is the replacement for `JSDocComment` .

```ts
ts.SyntaxKind.JSDoc === ts.SyntaxKind.JSDocComment
```
