### PR TITLE
feat: add isNamedDeclaration

### DIFF
--- a/src/nodes/typeGuards/compound.ts
+++ b/src/nodes/typeGuards/compound.ts
@@ -61,6 +61,23 @@ export function isJsxTagNamePropertyAccess(
 	);
 }
 
+/**
+ * ts.NamedDeclaration but the name property isn't optional.
+ */
+export interface NamedDeclaration extends ts.NamedDeclaration {
+	name: ts.NamedDeclaration["name"] extends infer T | undefined
+		? T extends undefined
+			? never
+			: T
+		: never;
+}
+
+export function isNamedDeclaration(
+	node: ts.Declaration
+): node is NamedDeclaration {
+	return "name" in node;
+}
+
 export function isNamespaceDeclaration(
 	node: ts.Node
 ): node is ts.NamespaceDeclaration {

--- a/src/nodes/typeGuards/compound.ts
+++ b/src/nodes/typeGuards/compound.ts
@@ -2,6 +2,7 @@ import * as ts from "typescript";
 
 import { isSuperExpression } from "./single.js";
 import {
+	isDeclarationName,
 	isEntityNameExpression,
 	isJSDocNamespaceBody,
 	isJsxTagNameExpression,
@@ -68,7 +69,12 @@ export interface NamedDeclarationWithName extends ts.NamedDeclaration {
 export function isNamedDeclarationWithName(
 	node: ts.Declaration
 ): node is NamedDeclarationWithName {
-	return "name" in node;
+	return (
+		"name" in node &&
+		node.name !== undefined &&
+		node.name !== null &&
+		isDeclarationName(node.name as ts.Node)
+	);
 }
 
 export function isNamespaceDeclaration(

--- a/src/nodes/typeGuards/compound.ts
+++ b/src/nodes/typeGuards/compound.ts
@@ -61,20 +61,13 @@ export function isJsxTagNamePropertyAccess(
 	);
 }
 
-/**
- * ts.NamedDeclaration but the name property isn't optional.
- */
-export interface NamedDeclaration extends ts.NamedDeclaration {
-	name: ts.NamedDeclaration["name"] extends infer T | undefined
-		? T extends undefined
-			? never
-			: T
-		: never;
+export interface NamedDeclarationWithName extends ts.NamedDeclaration {
+	name: NonNullable<ts.NamedDeclaration["name"]>;
 }
 
-export function isNamedDeclaration(
+export function isNamedDeclarationWithName(
 	node: ts.Declaration
-): node is NamedDeclaration {
+): node is NamedDeclarationWithName {
 	return "name" in node;
 }
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue fix #0
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

re https://github.com/JoshuaKGoldberg/ts-api-utils/pull/16#discussion_r1106671329

Looking at how TypeScript internally uses `NamedDeclaration`, it is simply used for casting a `Declaration` to allow accessing the `name` property.
The only reason the `name` property seems to be optional, is to handle the case of a non-named `Declaration` being cast to `NamedDeclaration`.

In terms how an `isNamedDeclaration` type guard would practically work, the `name` property should be required. This means well have to use a slightly different type than ts's `NamedDeclaration`. This PR adds that type guard with makes such a change in the type being guarded.