### PR TITLE
fix: change `isFunctionScopeBoundary` return type to boolean

### DIFF
--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -3,12 +3,12 @@
 
 import * as ts from "typescript";
 
-export const enum ScopeBoundary {
-	None = 0,
-	Function = 1,
-}
-
-export function isFunctionScopeBoundary(node: ts.Node): ScopeBoundary {
+/**
+ * Is the node a scope boundary, specifically due to it being a function.
+ *
+ * @category Scopes
+ */
+export function isFunctionScopeBoundary(node: ts.Node): boolean {
 	switch (node.kind) {
 		case ts.SyntaxKind.FunctionExpression:
 		case ts.SyntaxKind.ArrowFunction:
@@ -26,13 +26,11 @@ export function isFunctionScopeBoundary(node: ts.Node): ScopeBoundary {
 		case ts.SyntaxKind.ConstructSignature:
 		case ts.SyntaxKind.ConstructorType:
 		case ts.SyntaxKind.FunctionType:
-			return ScopeBoundary.Function;
+			return true;
 		case ts.SyntaxKind.SourceFile:
 			// if SourceFile is no module, it contributes to the global scope and is therefore no scope boundary
-			return ts.isExternalModule(node as ts.SourceFile)
-				? ScopeBoundary.Function
-				: ScopeBoundary.None;
+			return ts.isExternalModule(node as ts.SourceFile);
 		default:
-			return ScopeBoundary.None;
+			return false;
 	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #68
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes the return type to a `boolean`.
