### PR TITLE
chore: ci: only push coverage changes when running after a release

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -3,6 +3,10 @@ name: Release Docs
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      push_coverage_changes:
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -72,18 +76,18 @@ jobs:
 
       - run: echo "COVERAGE_CHANGED=$(git status --porcelain -u | grep -c docs/coverage.svg)" >> $GITHUB_ENV
 
-      - if: ${{ env.COVERAGE_CHANGED != '0' }}
+      - if: ${{ inputs.push_coverage_changes && env.COVERAGE_CHANGED != '0' }}
         uses: ./.github/actions/unprotect-main
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
-      - if: ${{ env.COVERAGE_CHANGED != '0' }}
+      - if: ${{ inputs.push_coverage_changes && env.COVERAGE_CHANGED != '0' }}
         run: |
           git add docs/coverage.svg
           git commit -m "docs: updated documentation coverage"
           git push
 
-      - if: ${{ always() && env.COVERAGE_CHANGED != '0' }}
+      - if: ${{ always() && inputs.push_coverage_changes && env.COVERAGE_CHANGED != '0' }}
         uses: ./.github/actions/protect-main
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,5 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       - if: ${{ env.SHOULD_RELEASE != '0' }}
         uses: ./.github/workflows/release-docs.yml@main
+        with:
+          push_coverage_changes: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 docs/generated/
+docs/coverage.svg
 lib/
 pnpm-lock.yaml
 

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,8 @@
 		".github",
 		"CHANGELOG.md",
 		"coverage",
+		"docs/coverage.svg",
+		"docs/generated",
 		"lib",
 		"node_modules",
 		"pnpm-lock.yaml",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #93
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken
