### PR TITLE
fix: import typescript using default

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -65,6 +65,7 @@ module.exports = {
 		"regexp",
 		"simple-import-sort",
 		"typescript-sort-keys",
+		"unicorn",
 		"vitest",
 	],
 	root: true,
@@ -74,6 +75,17 @@ module.exports = {
 		"no-only-tests/no-only-tests": "error",
 		"simple-import-sort/exports": "error",
 		"simple-import-sort/imports": "error",
+		"unicorn/import-style": [
+			"error",
+			{
+				extendDefaultStyles: false,
+				styles: {
+					typescript: {
+						default: true,
+					},
+				},
+			},
+		],
 
 		// These on-by-default rules don't work well for this repo and we like them off.
 		"no-inner-declarations": "off",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"eslint-plugin-regexp": "^1.12.0",
 		"eslint-plugin-simple-import-sort": "^10.0.0",
 		"eslint-plugin-typescript-sort-keys": "^2.1.0",
+		"eslint-plugin-unicorn": "^46.0.0",
 		"eslint-plugin-vitest": "^0.0.54",
 		"http-serve": "^1.0.1",
 		"husky": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ specifiers:
   eslint-plugin-regexp: ^1.12.0
   eslint-plugin-simple-import-sort: ^10.0.0
   eslint-plugin-typescript-sort-keys: ^2.1.0
+  eslint-plugin-unicorn: ^46.0.0
   eslint-plugin-vitest: ^0.0.54
   http-serve: ^1.0.1
   husky: ^8.0.3
@@ -62,6 +63,7 @@ devDependencies:
   eslint-plugin-regexp: 1.12.0_eslint@8.35.0
   eslint-plugin-simple-import-sort: 10.0.0_eslint@8.35.0
   eslint-plugin-typescript-sort-keys: 2.1.0_6mj2wypvdnknez7kws2nfdgupi
+  eslint-plugin-unicorn: 46.0.0_eslint@8.35.0
   eslint-plugin-vitest: 0.0.54_ycpbpc6yetojsgtrx3mwntkhsu
   http-serve: 1.0.1
   husky: 8.0.3
@@ -974,6 +976,16 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@eslint-community/eslint-utils/4.2.0_eslint@8.35.0:
+    resolution: {integrity: sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.35.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
 
   /@eslint/eslintrc/2.0.0:
     resolution: {integrity: sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==}
@@ -2143,6 +2155,11 @@ packages:
       ieee754: 1.2.1
     dev: true
 
+  /builtin-modules/3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+    dev: true
+
   /builtins/5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
@@ -2301,6 +2318,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /clean-regexp/1.0.0:
+    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
+    engines: {node: '>=4'}
+    dependencies:
+      escape-string-regexp: 1.0.5
+    dev: true
+
   /clean-stack/2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -2446,7 +2470,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
 
   /config-chain/1.1.13:
@@ -3288,6 +3312,31 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /eslint-plugin-unicorn/46.0.0_eslint@8.35.0:
+    resolution: {integrity: sha512-j07WkC+PFZwk8J33LYp6JMoHa1lXc1u6R45pbSAipjpfpb7KIGr17VE2D685zCxR5VL4cjrl65kTJflziQWMDA==}
+    engines: {node: '>=14.18'}
+    peerDependencies:
+      eslint: '>=8.28.0'
+    dependencies:
+      '@babel/helper-validator-identifier': 7.19.1
+      '@eslint-community/eslint-utils': 4.2.0_eslint@8.35.0
+      ci-info: 3.8.0
+      clean-regexp: 1.0.0
+      eslint: 8.35.0
+      esquery: 1.5.0
+      indent-string: 4.0.0
+      is-builtin-module: 3.2.1
+      jsesc: 3.0.2
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      read-pkg-up: 7.0.1
+      regexp-tree: 0.1.24
+      regjsparser: 0.9.1
+      safe-regex: 2.1.1
+      semver: 7.3.8
+      strip-indent: 3.0.0
     dev: true
 
   /eslint-plugin-vitest/0.0.54_ycpbpc6yetojsgtrx3mwntkhsu:
@@ -4288,6 +4337,13 @@ packages:
       has-tostringtag: 1.0.0
     dev: true
 
+  /is-builtin-module/3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.3.0
+    dev: true
+
   /is-callable/1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -4654,9 +4710,20 @@ packages:
     hasBin: true
     dev: true
 
+  /jsesc/0.5.0:
+    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
+    hasBin: true
+    dev: true
+
   /jsesc/2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
+    hasBin: true
+    dev: true
+
+  /jsesc/3.0.2:
+    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
+    engines: {node: '>=6'}
     hasBin: true
     dev: true
 
@@ -5852,6 +5919,11 @@ packages:
       irregular-plurals: 3.4.1
     dev: true
 
+  /pluralize/8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: true
+
   /pnpm-deduplicate/0.4.2:
     resolution: {integrity: sha512-CjnXgS5ht74W1PLaUWaGvTQ46oZqg5k7727kHs8MUOCZHbYKiMtvdf7mWp0rLP9HknuhxniKp5ZidVJpPpAOAg==}
     deprecated: pnpm v7.26.0 supports built-in `pnpm dedupe` command
@@ -6137,6 +6209,11 @@ packages:
       regexpp: 3.2.0
     dev: true
 
+  /regexp-tree/0.1.24:
+    resolution: {integrity: sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==}
+    hasBin: true
+    dev: true
+
   /regexp.prototype.flags/1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
@@ -6163,6 +6240,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       rc: 1.2.8
+    dev: true
+
+  /regjsparser/0.9.1:
+    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
+    hasBin: true
+    dependencies:
+      jsesc: 0.5.0
     dev: true
 
   /release-it/15.7.0:
@@ -6353,6 +6437,12 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
       is-regex: 1.1.4
+    dev: true
+
+  /safe-regex/2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
+    dependencies:
+      regexp-tree: 0.1.24
     dev: true
 
   /safer-buffer/2.1.2:

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { forEachToken } from "./tokens.js";
 

--- a/src/compilerOptions.test.ts
+++ b/src/compilerOptions.test.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/src/compilerOptions.ts
+++ b/src/compilerOptions.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 /**
  * An option that can be tested with {@link isCompilerOptionEnabled}.

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 /**
  * Test if the given flag is set on the combined flags.

--- a/src/modifiers.ts
+++ b/src/modifiers.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 /**
  * Test if the given iterable includes a modifier of any of the given kinds.

--- a/src/nodes/typeGuards/compound.test.ts
+++ b/src/nodes/typeGuards/compound.test.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createNode } from "../../test/utils.js";

--- a/src/nodes/typeGuards/compound.ts
+++ b/src/nodes/typeGuards/compound.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { isSuperExpression } from "./single.js";
 import {

--- a/src/nodes/typeGuards/single.ts
+++ b/src/nodes/typeGuards/single.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 /**
  * A node that represents the any keyword.

--- a/src/nodes/typeGuards/union.ts
+++ b/src/nodes/typeGuards/union.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { isTsVersionAtLeast } from "../../utils.js";
 import {

--- a/src/nodes/utilities.ts
+++ b/src/nodes/utilities.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 import {
 	isConstAssertionExpression,

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 /**
  * Is the node a scope boundary, specifically due to it being a function.

--- a/src/syntax.test.ts
+++ b/src/syntax.test.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 /**
  * Test of the kind given is for assignment.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -3,7 +3,7 @@
 // Original license MIT:
 // https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { isTsVersionAtLeast } from "./utils.js";
 

--- a/src/types/getters.test.ts
+++ b/src/types/getters.test.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../test/utils.js";

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { isNamedDeclarationWithName } from "../nodes/typeGuards/index.js";
 import {

--- a/src/types/typeGuards/compound.test.ts
+++ b/src/types/typeGuards/compound.test.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../../test/utils.js";

--- a/src/types/typeGuards/compound.ts
+++ b/src/types/typeGuards/compound.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { isTypeFlagSet } from "../../flags.js";
 import { isTupleType, isTypeReference } from "./objects.js";

--- a/src/types/typeGuards/objects.ts
+++ b/src/types/typeGuards/objects.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { isObjectFlagSet } from "../../flags.js";
 import { isObjectType } from "./simple.js";

--- a/src/types/typeGuards/simple.test.ts
+++ b/src/types/typeGuards/simple.test.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../../test/utils.js";

--- a/src/types/utilities.test.ts
+++ b/src/types/utilities.test.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../test/utils.js";

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 import {
 	isModifierFlagSet,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 const [tsMajor, tsMinor] = ts.versionMajorMinor
 	.split(".")


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #156
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Use `import ts from "typescript"` instead of `import * as ts from "typescript"`.

Also adds eslint rule [`unicorn/import-style`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/import-style.md) to enforce this.
