### PR TITLE
feat: add typeParts function

### DIFF
--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -54,9 +54,9 @@ export function isFalsyType(type: ts.Type): boolean {
 }
 
 /**
- * Get the union type parts of the given type.
+ * Get the intersection type parts of the given type.
  *
- * If the given type is not a union type, an array contain only that type will be returned.
+ * If the given type is not a intersection type, an array contain only that type will be returned.
  * @category Types - Utilities
  * @example
  * ```ts
@@ -69,6 +69,26 @@ export function isFalsyType(type: ts.Type): boolean {
  */
 export function intersectionTypeParts(type: ts.Type): ts.Type[] {
 	return isIntersectionType(type) ? type.types : [type];
+}
+
+/**
+ * Get the intersection or union type parts of the given type.
+ *
+ * Note that this is a shallow collection: it only returns `type.types` or `[type]`.
+ *
+ * If the given type is not an intersection or union type, an array contain only that type will be returned.
+ * @category Types - Utilities
+ * @example
+ * ```ts
+ * declare const type: ts.Type;
+ *
+ * for (const typePart of intersectionTypeParts(type)) {
+ *   // ...
+ * }
+ * ```
+ */
+export function typeParts(type: ts.Type): ts.Type[] {
+	return isIntersectionType(type) || isUnionType(type) ? type.types : [type];
 }
 
 function isReadonlyPropertyIntersection(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #258
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds in a shallow `typeParts` function. It's roughly equivalent to the existing `intersectionTypeParts` and `unionTypeParts` functions.

Doesn't add in a `{ recursive?: boolean }` or anything like that.