### PR TITLE
fix: downgrade engines.node to >=16

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 	},
 	"packageManager": "pnpm@8.15.1",
 	"engines": {
-		"node": ">=18"
+		"node": ">=16"
 	},
 	"publishConfig": {
 		"provenance": true


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #389
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Reduces the number in the `package.json` `engines` field.