### PR TITLE
fix: remove `.value` field from type declarations for boolean literal types

### DIFF
--- a/src/types/typeGuards/literal.test.ts
+++ b/src/types/typeGuards/literal.test.ts
@@ -59,8 +59,7 @@ describe("booleans don't have .value", () => {
 			const booleanLiteralType = type as BooleanLiteralType;
 			expect(booleanLiteralType.intrinsicName).toEqual(trueOrFalse);
 
-			// @ts-expect-error: boolean literals don't have a value
-			expect(booleanLiteralType.value).toBeUndefined();
+			expect(booleanLiteralType).not.toHaveProperty("value");
 		});
 	}
 });

--- a/src/types/typeGuards/literal.test.ts
+++ b/src/types/typeGuards/literal.test.ts
@@ -44,10 +44,10 @@ describe.each([
 });
 
 describe("booleans don't have .value", () => {
-	for (const tf of ["true", "false"]) {
-		it("is a boolean literal type", () => {
+	for (const trueOrFalse of ["true", "false"]) {
+		it(`should show that ${trueOrFalse} is a boolean literal type but doesn't have a .value field`, () => {
 			const { sourceFile, typeChecker } = createSourceFileAndTypeChecker(`
-			declare const x: ${tf};
+			declare const x: ${trueOrFalse};
 		`);
 
 			const node = (sourceFile.statements[0] as ts.VariableStatement)
@@ -57,7 +57,7 @@ describe("booleans don't have .value", () => {
 
 			expect(isBooleanLiteralType(type)).toBe(true);
 			const booleanLiteralType = type as BooleanLiteralType;
-			expect(booleanLiteralType.intrinsicName).toEqual(tf);
+			expect(booleanLiteralType.intrinsicName).toEqual(trueOrFalse);
 
 			// @ts-expect-error: boolean literals don't have a value
 			expect(booleanLiteralType.value).toBeUndefined();

--- a/src/types/typeGuards/literal.test.ts
+++ b/src/types/typeGuards/literal.test.ts
@@ -47,8 +47,8 @@ describe("booleans don't have .value", () => {
 	for (const trueOrFalse of ["true", "false"]) {
 		it(`should show that ${trueOrFalse} is a boolean literal type but doesn't have a .value field`, () => {
 			const { sourceFile, typeChecker } = createSourceFileAndTypeChecker(`
-			declare const x: ${trueOrFalse};
-		`);
+				declare const x: ${trueOrFalse};
+			`);
 
 			const node = (sourceFile.statements[0] as ts.VariableStatement)
 				.declarationList.declarations[0].name;

--- a/src/types/typeGuards/literal.test.ts
+++ b/src/types/typeGuards/literal.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../../test/utils";
 import {
+	BooleanLiteralType,
 	isBigIntLiteralType,
+	isBooleanLiteralType,
 	isFalseLiteralType,
 	isLiteralType,
 	isNumberLiteralType,
@@ -39,4 +41,26 @@ describe.each([
 			expect(typeGuard(type)).toEqual(expected);
 		});
 	});
+});
+
+describe("booleans don't have .value", () => {
+	for (const tf of ["true", "false"]) {
+		it("is a boolean literal type", () => {
+			const { sourceFile, typeChecker } = createSourceFileAndTypeChecker(`
+			declare const x: ${tf};
+		`);
+
+			const node = (sourceFile.statements[0] as ts.VariableStatement)
+				.declarationList.declarations[0].name;
+
+			const type = typeChecker.getTypeAtLocation(node);
+
+			expect(isBooleanLiteralType(type)).toBe(true);
+			const booleanLiteralType = type as BooleanLiteralType;
+			expect(booleanLiteralType.intrinsicName).toEqual(tf);
+
+			// @ts-expect-error: boolean literals don't have a value
+			expect(booleanLiteralType.value).toBeUndefined();
+		});
+	}
 });

--- a/src/types/typeGuards/literal.ts
+++ b/src/types/typeGuards/literal.ts
@@ -168,15 +168,16 @@ export function isTrueLiteralType(type: ts.Type): type is TrueLiteralType {
 
 /**
  * `LiteralType` from typescript except that it allows for it to work on arbitrary types.
+ * @deprecated Use {@link FreshableIntrinsicType} instead.
  * @category Type Types
  */
-// TODO - resolve what to do with this apparently-useless type.
-// See https://github.com/JoshuaKGoldberg/ts-api-utils/pull/535#discussion_r1845527367
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface UnknownLiteralType extends FreshableIntrinsicType {}
+export interface UnknownLiteralType extends FreshableIntrinsicType {
+	value?: unknown;
+}
 
 /**
  * Test if a type is a {@link UnknownLiteralType}.
+ * @deprecated Use {@link isFreshableIntrinsicType} instead.
  * @category Types - Type Guards
  * @example
  * ```ts

--- a/src/types/typeGuards/literal.ts
+++ b/src/types/typeGuards/literal.ts
@@ -10,7 +10,6 @@ import { type FreshableIntrinsicType } from "./compound";
  */
 export interface BooleanLiteralType extends UnknownLiteralType {
 	intrinsicName: "false" | "true";
-	value: boolean;
 }
 
 /**
@@ -55,7 +54,6 @@ export function isBigIntLiteralType(
  */
 export interface FalseLiteralType extends BooleanLiteralType {
 	intrinsicName: "false";
-	value: false;
 }
 
 /**
@@ -150,7 +148,6 @@ export function isTemplateLiteralType(
  */
 export interface TrueLiteralType extends BooleanLiteralType {
 	intrinsicName: "true";
-	value: true;
 }
 
 /**
@@ -173,9 +170,7 @@ export function isTrueLiteralType(type: ts.Type): type is TrueLiteralType {
  * `LiteralType` from typescript except that it allows for it to work on arbitrary types.
  * @category Type Types
  */
-export interface UnknownLiteralType extends FreshableIntrinsicType {
-	value: unknown;
-}
+export interface UnknownLiteralType extends FreshableIntrinsicType {}
 
 /**
  * Test if a type is a {@link UnknownLiteralType}.

--- a/src/types/typeGuards/literal.ts
+++ b/src/types/typeGuards/literal.ts
@@ -8,7 +8,7 @@ import { type FreshableIntrinsicType } from "./compound";
  * i.e. Either a "true" or "false" literal.
  * @category Type Types
  */
-export interface BooleanLiteralType extends UnknownLiteralType {
+export interface BooleanLiteralType extends FreshableIntrinsicType {
 	intrinsicName: "false" | "true";
 }
 
@@ -190,6 +190,7 @@ export interface UnknownLiteralType extends FreshableIntrinsicType {
  */
 export function isUnknownLiteralType(
 	type: ts.Type,
+	// eslint-disable-next-line deprecation/deprecation
 ): type is UnknownLiteralType {
 	return isTypeFlagSet(type, ts.TypeFlags.Literal);
 }

--- a/src/types/typeGuards/literal.ts
+++ b/src/types/typeGuards/literal.ts
@@ -170,6 +170,9 @@ export function isTrueLiteralType(type: ts.Type): type is TrueLiteralType {
  * `LiteralType` from typescript except that it allows for it to work on arbitrary types.
  * @category Type Types
  */
+// TODO - resolve what to do with this apparently-useless type.
+// See https://github.com/JoshuaKGoldberg/ts-api-utils/pull/535#discussion_r1845527367
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface UnknownLiteralType extends FreshableIntrinsicType {}
 
 /**


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #528 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Ostensibly, this is the code change, but it looks pretty intentional that it was written this way in the first place, so.... maybe needs some more investigation in order to understand why it was written this way.

<s>I'm not really sure how to test for this, either. I've written a test that proves the bug's existence, but wouldn't prevent it from regressing. Open to suggestions 🤔</s> I've written a test that proves the bug's existence at runtime, _and_ will cause a type-checking error if the `value` field is added back, due to its use of `@ts-expect-error`
