### PR TITLE
fix: make `isFalsyType()` return `true` for `0n`

### DIFF
--- a/src/types/utilities.test.ts
+++ b/src/types/utilities.test.ts
@@ -173,6 +173,9 @@ describe("isFalsyType", () => {
 		[true, "false"],
 		[true, "0"],
 		[true, "null"],
+		[true, "0n"],
+		[true, "-0n"],
+		[false, "24n"],
 	])("returns %j when given %s", (expected, source) => {
 		const { sourceFile, typeChecker } = createSourceFileAndTypeChecker(`
 			${source};

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -47,7 +47,11 @@ export function isFalsyType(type: ts.Type): boolean {
 	}
 
 	if (type.isLiteral()) {
-		return !type.value;
+		if (typeof type.value === "object") {
+			return type.value.base10Value === "0";
+		} else {
+			return !type.value;
+		}
 	}
 
 	return isFalseLiteralType(type);

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -1,6 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
+import semver from "semver";
 import ts from "typescript";
 
 import {
@@ -46,7 +47,7 @@ export function isFalsyType(type: ts.Type): boolean {
 		return true;
 	}
 
-	if (type.isLiteral()) {
+	if (typeIsLiteral(type)) {
 		if (typeof type.value === "object") {
 			return type.value.base10Value === "0";
 		} else {
@@ -400,4 +401,25 @@ export function symbolHasReadonlyDeclaration(
  */
 export function unionTypeParts(type: ts.Type): ts.Type[] {
 	return isUnionType(type) ? type.types : [type];
+}
+
+/**
+ * TS's `type.isLiteral()` is bugged before TS v5.0 and won't return `true` for
+ * bigint literals. Use this function instead if you need to check for bigint
+ * literals in TS versions before v5.0. Otherwise, you should just use
+ * `type.isLiteral()`.
+ *
+ * See https://github.com/microsoft/TypeScript/pull/50929
+ */
+export function typeIsLiteral(type: ts.Type): type is ts.LiteralType {
+	if (semver.lt(ts.version, "5.0.0")) {
+		return isTypeFlagSet(
+			type,
+			ts.TypeFlags.StringLiteral |
+				ts.TypeFlags.NumberLiteral |
+				ts.TypeFlags.BigIntLiteral,
+		);
+	} else {
+		return type.isLiteral();
+	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #544 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
The `type.value` returns a `PseudoBigInt` object rather than an actual bigint for TS legacy support reasons. Therefore, to determine if a literal is a falsy value, we cannot rely on the truthiness of `type.value` alone, and need to check what the actual object is if it's not a primitive.