### PR TITLE
build: shrink size of bundle

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
 	entry: ["src/index.ts"],
 	format: ["cjs", "esm"],
 	outDir: "lib",
-	sourcemap: true,
+	sourcemap: false,
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
 	format: ["cjs", "esm"],
 	outDir: "lib",
 	sourcemap: false,
+	target: "node16",
+	treeshake: {
+		preset: "smallest",
+	},
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
 	clean: true,
 	dts: true,
-	entry: ["src/**/*.ts", "!src/**/*.test.*"],
+	entry: ["src/index.ts"],
 	format: ["cjs", "esm"],
 	outDir: "lib",
 	sourcemap: true,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #573
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Turns off the ESBuild bundling that was done with tsup. It was including packages from `node_modules/`. 😩 

Running `du -sh lib/`:
* Baseline (`main`): 1.1M
* With this change: 184K

❤️‍🔥 