### PR TITLE
refactor: use namespace import to import "typescript"

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -152,6 +152,16 @@ module.exports = {
 			{ argsIgnorePattern: "^_", caughtErrors: "all" },
 		],
 
+		"no-restricted-syntax": [
+			"error",
+			// Forbid default import from "typescript"
+			{
+				message: 'Default import from "typescript" is not allowed.',
+				selector:
+					'ImportDeclaration[source.value="typescript"] > ImportDefaultSpecifier',
+			},
+		],
+
 		// These on-by-default rules don't work well for this repo and we like them off.
 		"n/no-missing-import": "off",
 		"no-case-declarations": "off",

--- a/src/comments.test.ts
+++ b/src/comments.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it, vitest } from "vitest";
 
 import { forEachComment } from "./comments";

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { forEachToken } from "./tokens";
 

--- a/src/compilerOptions.test.ts
+++ b/src/compilerOptions.test.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/src/compilerOptions.ts
+++ b/src/compilerOptions.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * An option that can be tested with {@link isCompilerOptionEnabled}.

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * Test if the given flag is set on the combined flags.

--- a/src/modifiers.ts
+++ b/src/modifiers.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * Test if the given iterable includes a modifier of any of the given kinds.

--- a/src/nodes/access.test.ts
+++ b/src/nodes/access.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createNode } from "../test/utils";

--- a/src/nodes/access.ts
+++ b/src/nodes/access.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isAssignmentKind } from "../syntax";
 

--- a/src/nodes/typeGuards/compound.test.ts
+++ b/src/nodes/typeGuards/compound.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createNode } from "../../test/utils";

--- a/src/nodes/typeGuards/compound.ts
+++ b/src/nodes/typeGuards/compound.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isSuperExpression } from "./single";
 import {

--- a/src/nodes/typeGuards/single.test.ts
+++ b/src/nodes/typeGuards/single.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createNode } from "../../test/utils";

--- a/src/nodes/typeGuards/single.ts
+++ b/src/nodes/typeGuards/single.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * A node that represents the any keyword.

--- a/src/nodes/typeGuards/union.test.ts
+++ b/src/nodes/typeGuards/union.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createNode } from "../../test/utils";

--- a/src/nodes/typeGuards/union.ts
+++ b/src/nodes/typeGuards/union.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isTsVersionAtLeast } from "../../utils";
 import {

--- a/src/nodes/utilities.ts
+++ b/src/nodes/utilities.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isTransientSymbolLinksFlagSet } from "../flags";
 import {

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * Is the node a scope boundary, specifically due to it being a function.

--- a/src/syntax.test.ts
+++ b/src/syntax.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * Test of the kind given is for assignment.

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,5 +1,5 @@
 import * as tsvfs from "@typescript/vfs";
-import ts from "typescript";
+import * as ts from "typescript";
 
 export function createNodeAndSourceFile<Node extends ts.Node>(
 	sourceText: string,

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -3,7 +3,7 @@
 // Original license MIT:
 // https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * Callback type used for {@link forEachToken}.

--- a/src/types/getters.test.ts
+++ b/src/types/getters.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../test/utils";

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isNamedDeclarationWithName } from "../nodes/typeGuards";
 import {

--- a/src/types/typeGuards/compound.test.ts
+++ b/src/types/typeGuards/compound.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../../test/utils";

--- a/src/types/typeGuards/compound.ts
+++ b/src/types/typeGuards/compound.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { type IntrinsicType, isIntrinsicType } from "./intrinsic";
 import { isTupleType, isTypeReference } from "./objects";

--- a/src/types/typeGuards/intrinsic.test.ts
+++ b/src/types/typeGuards/intrinsic.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../../test/utils";

--- a/src/types/typeGuards/intrinsic.ts
+++ b/src/types/typeGuards/intrinsic.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isTypeFlagSet } from "../../flags";
 

--- a/src/types/typeGuards/literal.test.ts
+++ b/src/types/typeGuards/literal.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../../test/utils";

--- a/src/types/typeGuards/literal.ts
+++ b/src/types/typeGuards/literal.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isTypeFlagSet } from "../../flags";
 import { type FreshableIntrinsicType } from "./compound";

--- a/src/types/typeGuards/objects.ts
+++ b/src/types/typeGuards/objects.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isObjectFlagSet } from "../../flags";
 import { isObjectType } from "./single";

--- a/src/types/typeGuards/single.test.ts
+++ b/src/types/typeGuards/single.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../../test/utils";

--- a/src/types/typeGuards/single.ts
+++ b/src/types/typeGuards/single.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isTypeFlagSet } from "../../flags";
 

--- a/src/types/utilities.test.ts
+++ b/src/types/utilities.test.ts
@@ -1,5 +1,5 @@
 import semver from "semver";
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { createSourceFileAndTypeChecker } from "../test/utils";

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -2,7 +2,7 @@
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
 import semver from "semver";
-import ts from "typescript";
+import * as ts from "typescript";
 
 import {
 	isModifierFlagSet,

--- a/src/usage/Scope.ts
+++ b/src/usage/Scope.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import type { EnumScope, NamespaceScope } from "./scopes";
 

--- a/src/usage/UsageWalker.ts
+++ b/src/usage/UsageWalker.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { includesModifier } from "../modifiers";
 import {

--- a/src/usage/collectVariableUsage.test.ts
+++ b/src/usage/collectVariableUsage.test.ts
@@ -1,5 +1,5 @@
 import { query } from "@phenomnomnominal/tsquery";
-import ts from "typescript";
+import * as ts from "typescript";
 import { describe, expect, test } from "vitest";
 
 import { createSourceFile } from "../test/utils";

--- a/src/usage/collectVariableUsage.ts
+++ b/src/usage/collectVariableUsage.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { UsageWalker } from "./UsageWalker";
 import { UsageInfo } from "./usage";

--- a/src/usage/declarations.ts
+++ b/src/usage/declarations.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { identifierToKeywordKind } from "./utils";
 

--- a/src/usage/getPropertyName.ts
+++ b/src/usage/getPropertyName.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { isNumericOrStringLikeLiteral } from "../nodes/typeGuards/compound";
 

--- a/src/usage/getUsageDomain.ts
+++ b/src/usage/getUsageDomain.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { identifierToKeywordKind } from "./utils";
 

--- a/src/usage/scopes.ts
+++ b/src/usage/scopes.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { Scope, ScopeBoundary, ScopeBoundarySelector } from "./Scope";
 import {

--- a/src/usage/usage.ts
+++ b/src/usage/usage.ts
@@ -1,7 +1,7 @@
 // Code largely based on https://github.com/ajafff/tsutils
 // Original license: https://github.com/ajafff/tsutils/blob/26b195358ec36d59f00333115aa3ffd9611ca78b/LICENSE
 
-import ts from "typescript";
+import * as ts from "typescript";
 
 import { Scope } from "./Scope";
 import { DeclarationDomain, DeclarationInfo } from "./declarations";

--- a/src/usage/utils.ts
+++ b/src/usage/utils.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * Supports TypeScript<5 versions that don't have identifierToKeywordKind.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 
 const [tsMajor, tsMinor] = ts.versionMajorMinor
 	.split(".")


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

In build script of Prettier, we transform the typescript package to ESM for better tree-shake, then we [rewrite "import"s
 from `ts-api-utils`](https://github.com/prettier/prettier/blob/96d2fe439dcf784806d6543c422fe6ffe679ca4c/scripts/build/config.js#L278), do you think it's acceptable to use namespace import here? so we don't need rewrite these "import"s.

