### PR TITLE
fix: make `isTypeParameter` no longer a typeguard

### DIFF
--- a/src/types/typeGuards/single.ts
+++ b/src/types/typeGuards/single.ts
@@ -177,8 +177,10 @@ export function isSubstitutionType(type: ts.Type): type is ts.SubstitutionType {
  *   // ...
  * }
  * ```
+ *
+ * Note - is intentional that this is not a type guard. See https://github.com/JoshuaKGoldberg/ts-api-utils/issues/382
  */
-export function isTypeParameter(type: ts.Type): type is ts.TypeParameter {
+export function isTypeParameter(type: ts.Type): boolean {
 	return isTypeFlagSet(type, ts.TypeFlags.TypeParameter);
 }
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #382 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes return type, adds tests, including type tests. These (intentionally) _will break_ as a TS typechecking error if `ts.TypeParameter` becomes distinguishable from `ts.Type` in the future.