### PR TITLE
test: fill in test coverage for comments.ts

### DIFF
--- a/src/comments.test.ts
+++ b/src/comments.test.ts
@@ -3,10 +3,9 @@ import { describe, expect, it, vitest } from "vitest";
 
 import { forEachComment } from "./comments";
 import { createNodeAndSourceFile } from "./test/utils";
-import { isTsVersionAtLeast } from "./utils";
 
 describe("forEachComment", () => {
-	it("does not call the callback when the source has no comments", () => {
+	it("does not call the callback when the source is a variable with no comments", () => {
 		const { node, sourceFile } = createNodeAndSourceFile("let value;");
 		const callback = vitest.fn();
 
@@ -15,38 +14,102 @@ describe("forEachComment", () => {
 		expect(callback).not.toHaveBeenCalled();
 	});
 
-	if (isTsVersionAtLeast(4, 3)) {
-		it("calls the callback when the source has a leading comment", () => {
-			const { node, sourceFile } = createNodeAndSourceFile(`
+	it("calls the callback when the source is a variable with a leading comment", () => {
+		const { node, sourceFile } = createNodeAndSourceFile(`
+			// hello world
+			let value;
+		`);
+		const callback = vitest.fn();
+
+		forEachComment(node, callback, sourceFile);
+
+		expect(callback).toHaveBeenCalledWith(
+			sourceFile.getFullText(),
+			expect.objectContaining({
+				kind: ts.SyntaxKind.SingleLineCommentTrivia,
+			}),
+		);
+	});
+
+	it("calls the callback when the source is a inside a JSX element with a leading comment", () => {
+		const { node, sourceFile } = createNodeAndSourceFile(`
+			let value = (
+				<div>
+				{
+					// hello world	
+					'asdf'
+				}
+				</div>
+			);
+		`);
+		const callback = vitest.fn();
+
+		forEachComment(node, callback, sourceFile);
+
+		expect(callback).toHaveBeenCalledWith(
+			sourceFile.getFullText(),
+			expect.objectContaining({
+				kind: ts.SyntaxKind.SingleLineCommentTrivia,
+			}),
+		);
+	});
+
+	it("calls the callback when the source is a inside a JSX fragment with a leading comment", () => {
+		const { node, sourceFile } = createNodeAndSourceFile(`
+			let value = (
+				<>
+				{
+					// hello world	
+					'asdf'
+				}
+				</>
+			);
+		`);
+		const callback = vitest.fn();
+
+		forEachComment(node, callback, sourceFile);
+
+		expect(callback).toHaveBeenCalledWith(
+			sourceFile.getFullText(),
+			expect.objectContaining({
+				kind: ts.SyntaxKind.SingleLineCommentTrivia,
+			}),
+		);
+	});
+
+	it("calls the callback when the source is a inside a JSX self-closing element with a leading comment", () => {
+		const { node, sourceFile } = createNodeAndSourceFile(`
+			let value = (
+				<div {
 				// hello world
-				let value;
-			`);
-			const callback = vitest.fn();
-
-			forEachComment(node, callback, sourceFile);
-
-			expect(callback).toHaveBeenCalledWith(
-				sourceFile.getFullText(),
-				expect.objectContaining({
-					kind: ts.SyntaxKind.SingleLineCommentTrivia,
-				}),
+				} />
 			);
-		});
+		`);
+		const callback = vitest.fn();
 
-		it("calls the callback when the source has a trailing comment", () => {
-			const { node, sourceFile } = createNodeAndSourceFile(`
-				let value; // hello world
-			`);
-			const callback = vitest.fn();
+		forEachComment(node, callback, sourceFile);
 
-			forEachComment(node, callback, sourceFile);
+		expect(callback).toHaveBeenCalledWith(
+			sourceFile.getFullText(),
+			expect.objectContaining({
+				kind: ts.SyntaxKind.SingleLineCommentTrivia,
+			}),
+		);
+	});
 
-			expect(callback).toHaveBeenCalledWith(
-				sourceFile.getFullText(),
-				expect.objectContaining({
-					kind: ts.SyntaxKind.SingleLineCommentTrivia,
-				}),
-			);
-		});
-	}
+	it("calls the callback when the source is a variable with a trailing comment", () => {
+		const { node, sourceFile } = createNodeAndSourceFile(`
+			let value; // hello world
+		`);
+		const callback = vitest.fn();
+
+		forEachComment(node, callback, sourceFile);
+
+		expect(callback).toHaveBeenCalledWith(
+			sourceFile.getFullText(),
+			expect.objectContaining({
+				kind: ts.SyntaxKind.SingleLineCommentTrivia,
+			}),
+		);
+	});
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #14
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Raises test coverage by about 3%.

Also removes a `isTsVersionAtLeast` that's unnecessary as of #531. 

💖 