### PR TITLE
chore: bump actions/upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - if: steps.should_release.outputs.should_release != '0'
         name: Create a pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/generated
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #700
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I checked https://github.com/actions/upload-pages-artifact/releases and it _seems_ like there's nothing else to update?

💖 