### PR TITLE
test: adjust `createSourceFileAndTypeChecker` to verify passed code has valid syntax

### DIFF
--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -65,6 +65,17 @@ export function createSourceFileAndTypeChecker(
 		throw new Error("Failed to get program.");
 	}
 
+	const diagnostics = program.getSyntacticDiagnostics();
+
+	if (diagnostics.length > 0) {
+		throw new Error(
+			ts.flattenDiagnosticMessageText(
+				diagnostics[0].messageText,
+				ts.sys.newLine,
+			),
+		);
+	}
+
 	return {
 		sourceFile: program.getSourceFile(fileName)!,
 		typeChecker: program.getTypeChecker(),


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This is a small follow-up to https://github.com/JoshuaKGoldberg/ts-api-utils/pull/698#discussion_r1937536540, and it adjusts the test helper `createSourceFileAndTypeChecker` to check that passed syntax is valid (to prevent accidental invalid syntax on test cases).

I've checked locally that this would fail before the change on the linked comment.

---

Codecov fails on this, but I don't think there's much to do (it's a test helper, should it even be included in the codecov report?).