### PR TITLE
fix: isPropertyReadonlyInType crash on readonly array of a generic arrow function parameter

### DIFF
--- a/src/nodes/utilities.ts
+++ b/src/nodes/utilities.ts
@@ -84,9 +84,12 @@ export function isInConstContext(
 				}
 
 				// I believe we only need to check one level deep, regardless of how deep `node` is.
-				return isTransientSymbolLinksFlagSet(
-					(propertySymbol as ts.TransientSymbol).links,
-					ts.CheckFlags.Readonly,
+				return (
+					!!propertySymbol.links &&
+					isTransientSymbolLinksFlagSet(
+						(propertySymbol as ts.TransientSymbol).links,
+						ts.CheckFlags.Readonly,
+					)
 				);
 			}
 			case ts.SyntaxKind.PrefixUnaryExpression:

--- a/src/types/utilities.test.ts
+++ b/src/types/utilities.test.ts
@@ -65,6 +65,26 @@ describe("isPropertyReadonlyInType", () => {
 			),
 		).toBe(false);
 	});
+
+	it("does not crash when the property is inside a readonly array of a generic arrow function parameter", () => {
+		const { sourceFile, typeChecker } = createSourceFileAndTypeChecker(`
+			declare const factory: <T>(x: readonly T[]) => (f: (x: T) => void) => void;
+
+			factory([{ abc: 42 }])((x) => { });
+		`);
+		const node = sourceFile.statements.at(-1) as ts.ExpressionStatement;
+		const call = node.expression as ts.CallExpression;
+		const parameter = call.arguments[0] as ts.ArrowFunction;
+		const type = typeChecker.getTypeAtLocation(parameter.parameters[0]);
+
+		expect(
+			isPropertyReadonlyInType(
+				type,
+				ts.escapeLeadingUnderscores("abc"),
+				typeChecker,
+			),
+		).toBe(false);
+	});
 });
 
 describe("symbolHasReadonlyDeclaration", () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #754
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The `propertySymbol` being checked in `isInConstContext` might not be a `ts.TransientSymbol` with `.links`.

💖