### PR TITLE
docs: deprecate symbolHasReadonlyDeclaration

### DIFF
--- a/src/types/utilities.test.ts
+++ b/src/types/utilities.test.ts
@@ -101,6 +101,7 @@ describe("symbolHasReadonlyDeclaration", () => {
 		const node = sourceFile.statements.at(-1) as ts.ExpressionStatement;
 		const symbol = typeChecker.getSymbolAtLocation(node.expression)!;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- Will be made private-only soon.
 		expect(symbolHasReadonlyDeclaration(symbol, typeChecker)).toBe(false);
 	});
 
@@ -117,6 +118,7 @@ describe("symbolHasReadonlyDeclaration", () => {
 		const node = sourceFile.statements.at(-1) as ts.ExpressionStatement;
 		const symbol = typeChecker.getSymbolAtLocation(node.expression)!;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- Will be made private-only soon.
 		expect(symbolHasReadonlyDeclaration(symbol, typeChecker)).toBe(true);
 	});
 
@@ -150,6 +152,7 @@ describe("symbolHasReadonlyDeclaration", () => {
 		const type = typeChecker.getTypeAtLocation(node.expression);
 		const symbol = type.getSymbol()!;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- Will be made private-only soon.
 		expect(symbolHasReadonlyDeclaration(symbol, typeChecker)).toBe(expected);
 	});
 
@@ -177,8 +180,14 @@ describe("symbolHasReadonlyDeclaration", () => {
 			expect(fooSymbol).toBeDefined();
 			expect(barSymbol).toBeDefined();
 			expect(bazSymbol).toBeDefined();
+
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- Will be made private-only soon.
 			expect(symbolHasReadonlyDeclaration(fooSymbol, typeChecker)).toBe(true);
+
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- Will be made private-only soon.
 			expect(symbolHasReadonlyDeclaration(barSymbol, typeChecker)).toBe(true);
+
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- Will be made private-only soon.
 			expect(symbolHasReadonlyDeclaration(bazSymbol, typeChecker)).toBe(false);
 		});
 	}

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -223,7 +223,7 @@ export function isThenableType(
  * }
  * ```
  * @deprecated This is not used by any consumers known by ts-api-utils,
- * and so will be removed in a future major version.
+ * and so the public export will be removed in a future major version.
  */
 export function symbolHasReadonlyDeclaration(
 	symbol: ts.Symbol,
@@ -451,6 +451,7 @@ function isReadonlyPropertyIntersection(
 			(
 				isSymbolFlagSet(prop, ts.SymbolFlags.ValueModule) ||
 				// we unwrapped every mapped type, now we can check the actual declarations
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- Will be made private-only soon.
 				symbolHasReadonlyDeclaration(prop, typeChecker)
 			)
 		);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #610
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `@deprecated` JSDocs tag. This is purely a docs change for now - it does not remove the function. The function is actually used by `isReadonlyPropertyIntersection`, so the next step would be to remove the `export` - not the whole function.

💖