### PR TITLE
ci: remove node 25 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,11 @@ jobs:
       matrix:
         node_version:
           - 18.x
+          - 20.x
           - 22.x
-          - latest
+          - 24.x
+          # Uncomment this when https://github.com/vitest-dev/vitest/issues/8757 has been resolved
+          # - latest
         ts_version:
           - 4.8.4
           - latest


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #768
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per vitest-dev/vitest#8757, vitest is throwing errors in node v25 due to some issues with the new webstorage api. Once this issue is resolved upstream, `latest` should be re-enabled.
