### PR TITLE
feat: `isStrictCompilerOptionEnabled` should default to `strict: true` for TS 6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
           - latest
         ts_version:
           - 4.8.4
-          - latest
+          - 5.9.3
+          - rc # TS 6 rc
 
 name: Test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,10 @@ jobs:
           - latest
         ts_version:
           - 4.8.4
-          - 5.9.3
-          - rc # TS 6 rc
+          - latest
+          # TS 6 rc. Once TS 6 is released, this can be removed, since it will
+          # be superseded by `latest`
+          - rc
 
 name: Test
 

--- a/src/compilerOptions.test.ts
+++ b/src/compilerOptions.test.ts
@@ -8,9 +8,10 @@ import {
 	isCompilerOptionEnabled,
 	isStrictCompilerOptionEnabled,
 } from "./compilerOptions";
+import { isTsVersionAtLeast } from "./utils";
 
 describe("isCompilerOptionEnabled", () => {
-	it("checks if option is enabled", () => {
+	it("checks if option is enabled explicitly", () => {
 		expect(isCompilerOptionEnabled({}, "allowJs")).toBe(false);
 		expect(isCompilerOptionEnabled({ allowJs: undefined }, "allowJs")).toBe(
 			false,
@@ -134,7 +135,7 @@ describe("isCompilerOptionEnabled", () => {
 		).toBe(false);
 		expect(
 			isCompilerOptionEnabled(
-				{ suppressImplicitAnyIndexErrors: true },
+				{ strict: false, suppressImplicitAnyIndexErrors: true },
 				"suppressImplicitAnyIndexErrors",
 			),
 		).toBe(false);
@@ -354,6 +355,16 @@ describe("isStrictCompilerOptionEnabled", () => {
 		).toBe(true);
 	});
 
+	it("correctly resolves strict option defaults", () => {
+		expect(isStrictCompilerOptionEnabled({}, "strictNullChecks")).toBe(
+			isTsVersionAtLeast(6),
+		);
+
+		expect(isStrictCompilerOptionEnabled({}, "noImplicitAny")).toBe(
+			isTsVersionAtLeast(6),
+		);
+	});
+
 	it("knows about strictPropertyInitializations dependency on strictNullChecks", () => {
 		expect(
 			isStrictCompilerOptionEnabled(
@@ -382,13 +393,13 @@ describe("isStrictCompilerOptionEnabled", () => {
 				{ strictPropertyInitialization: true },
 				"strictPropertyInitialization",
 			),
-		).toBe(false);
+		).toBe(isTsVersionAtLeast(6));
 		expect(
 			isStrictCompilerOptionEnabled(
 				{ strictNullChecks: true },
 				"strictPropertyInitialization",
 			),
-		).toBe(false);
+		).toBe(isTsVersionAtLeast(6));
 		expect(
 			isStrictCompilerOptionEnabled(
 				{ strict: false, strictPropertyInitialization: true },

--- a/src/compilerOptions.ts
+++ b/src/compilerOptions.ts
@@ -3,6 +3,8 @@
 
 import ts from "typescript";
 
+import { isTsVersionAtLeast } from "./utils";
+
 /* eslint-disable jsdoc/informative-docs */
 /**
  * An option that can be tested with {@link isCompilerOptionEnabled}.
@@ -136,9 +138,12 @@ export function isStrictCompilerOptionEnabled(
 	options: ts.CompilerOptions,
 	option: StrictCompilerOption,
 ): boolean {
-	return (
-		(options.strict ? options[option] !== false : options[option] === true) &&
-		(option !== "strictPropertyInitialization" ||
-			isStrictCompilerOptionEnabled(options, "strictNullChecks"))
-	);
+	if (option === "strictPropertyInitialization") {
+		// strictPropertyInitialization has no effect unless strictNullChecks is also enabled.
+		if (!isStrictCompilerOptionEnabled(options, "strictNullChecks")) {
+			return false;
+		}
+	}
+
+	return options[option] ?? options.strict ?? isTsVersionAtLeast(6);
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ts-api-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #870 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-api-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-api-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes the way the options are resolved to make sure the strict options are enabled by default.

For the test infra, I've added `typescript@rc` into the test matrix in order to test TS 6. Once TS 6 is actually released, `latest` will cover TS 6 and we can pin TS@5.9.3 to test the latest TS 5 version.